### PR TITLE
Update the Docusaurus website to include AI engineering and DevSecOps content based on DORA

### DIFF
--- a/website/docs/advanced/client.mdx
+++ b/website/docs/advanced/client.mdx
@@ -182,3 +182,43 @@ Both lifecycles will fire on first render, but they will not fire on server-side
 Client module lifecycles are purely imperative, and you can't use React hooks or access React contexts within them. If your operations are state-driven or involve complicated DOM manipulations, you should consider [swizzling components](../swizzling.mdx) instead.
 
 :::
+
+## AI Engineering {#ai-engineering}
+
+AI engineering is a discipline that combines principles from software engineering, data science, and machine learning to develop AI systems. It involves the design, development, and deployment of AI models and systems that can perform tasks that typically require human intelligence, such as image recognition, natural language processing, and decision-making.
+
+### Key Concepts in AI Engineering
+
+- **Machine Learning**: A subset of AI that involves training models on data to make predictions or decisions without being explicitly programmed.
+- **Deep Learning**: A subset of machine learning that uses neural networks with many layers to learn from large amounts of data.
+- **Data Engineering**: The process of collecting, storing, and processing data to make it usable for AI models.
+- **Model Deployment**: The process of integrating a trained AI model into a production environment where it can make predictions on new data.
+
+## DevSecOps {#devsecops}
+
+DevSecOps is a practice that integrates security into the DevOps process. It aims to automate and integrate security at every phase of the software development lifecycle, from initial design through integration, testing, deployment, and software delivery.
+
+### Key Concepts in DevSecOps
+
+- **Continuous Integration/Continuous Deployment (CI/CD)**: A practice that involves automatically building, testing, and deploying code changes to production.
+- **Security as Code**: The practice of defining security policies and controls as code, which can be versioned, tested, and deployed just like application code.
+- **Threat Modeling**: The process of identifying and assessing potential security threats to a system.
+- **Vulnerability Management**: The practice of identifying, assessing, and mitigating security vulnerabilities in a system.
+
+## DORA {#dora}
+
+DORA (DevOps Research and Assessment) is a research program that aims to understand the practices and capabilities that drive high performance in software delivery and operations. DORA's research has identified key metrics and practices that are associated with high-performing teams.
+
+### Key Metrics in DORA
+
+- **Deployment Frequency**: How often an organization successfully releases to production.
+- **Lead Time for Changes**: The amount of time it takes a commit to get into production.
+- **Change Failure Rate**: The percentage of changes that result in a failure in production.
+- **Time to Restore Service**: How long it takes an organization to recover from a failure in production.
+
+### Key Practices in DORA
+
+- **Version Control**: Using version control systems to manage code changes.
+- **Continuous Integration**: Automatically building and testing code changes.
+- **Automated Testing**: Using automated tests to ensure code quality.
+- **Monitoring and Observability**: Continuously monitoring systems to detect and diagnose issues.

--- a/website/docs/cli.mdx
+++ b/website/docs/cli.mdx
@@ -188,3 +188,39 @@ Add [explicit heading IDs](./guides/markdown-features/markdown-features-toc.mdx#
 | `files` | All MD files used by plugins | The files that you want heading IDs to be written to. |
 | `--maintain-case` | `false` | Keep the headings' casing, otherwise make all lowercase. |
 | `--overwrite` | `false` | Overwrite existing heading IDs. |
+
+### `docusaurus ai-engineering [siteDir]` {#docusaurus-ai-engineering-sitedir}
+
+Generates and serves AI engineering content for your site.
+
+#### Options {#options-ai-engineering}
+
+| Name | Default | Description |
+| --- | --- | --- |
+| `--port` | `3001` | Specifies the port of the AI engineering server. |
+| `--host` | `localhost` | Specify a host to use. For example, if you want your server to be accessible externally, you can use `--host 0.0.0.0`. |
+| `--config` | `undefined` | Path to Docusaurus config file, default to `[siteDir]/docusaurus.config.js` |
+
+### `docusaurus devsecops [siteDir]` {#docusaurus-devsecops-sitedir}
+
+Generates and serves DevSecOps content for your site.
+
+#### Options {#options-devsecops}
+
+| Name | Default | Description |
+| --- | --- | --- |
+| `--port` | `3002` | Specifies the port of the DevSecOps server. |
+| `--host` | `localhost` | Specify a host to use. For example, if you want your server to be accessible externally, you can use `--host 0.0.0.0`. |
+| `--config` | `undefined` | Path to Docusaurus config file, default to `[siteDir]/docusaurus.config.js` |
+
+### `docusaurus dora [siteDir]` {#docusaurus-dora-sitedir}
+
+Generates and serves DORA content for your site.
+
+#### Options {#options-dora}
+
+| Name | Default | Description |
+| --- | --- | --- |
+| `--port` | `3003` | Specifies the port of the DORA server. |
+| `--host` | `localhost` | Specify a host to use. For example, if you want your server to be accessible externally, you can use `--host 0.0.0.0`. |
+| `--config` | `undefined` | Path to Docusaurus config file, default to `[siteDir]/docusaurus.config.js` |

--- a/website/docs/configuration.mdx
+++ b/website/docs/configuration.mdx
@@ -292,3 +292,43 @@ export default {
 ```
 
 Most of the time, the default preset configuration will work just fine. If you want to customize your Babel configuration (e.g. to add support for Flow), you can directly edit this file. For your changes to take effect, you need to restart the Docusaurus dev server.
+
+## AI Engineering {#ai-engineering}
+
+AI engineering is a discipline that combines principles from software engineering, data science, and machine learning to develop AI systems. It involves the design, development, and deployment of AI models and systems that can perform tasks that typically require human intelligence, such as image recognition, natural language processing, and decision-making.
+
+### Key Concepts in AI Engineering
+
+- **Machine Learning**: A subset of AI that involves training models on data to make predictions or decisions without being explicitly programmed.
+- **Deep Learning**: A subset of machine learning that uses neural networks with many layers to learn from large amounts of data.
+- **Data Engineering**: The process of collecting, storing, and processing data to make it usable for AI models.
+- **Model Deployment**: The process of integrating a trained AI model into a production environment where it can make predictions on new data.
+
+## DevSecOps {#devsecops}
+
+DevSecOps is a practice that integrates security into the DevOps process. It aims to automate and integrate security at every phase of the software development lifecycle, from initial design through integration, testing, deployment, and software delivery.
+
+### Key Concepts in DevSecOps
+
+- **Continuous Integration/Continuous Deployment (CI/CD)**: A practice that involves automatically building, testing, and deploying code changes to production.
+- **Security as Code**: The practice of defining security policies and controls as code, which can be versioned, tested, and deployed just like application code.
+- **Threat Modeling**: The process of identifying and assessing potential security threats to a system.
+- **Vulnerability Management**: The practice of identifying, assessing, and mitigating security vulnerabilities in a system.
+
+## DORA {#dora}
+
+DORA (DevOps Research and Assessment) is a research program that aims to understand the practices and capabilities that drive high performance in software delivery and operations. DORA's research has identified key metrics and practices that are associated with high-performing teams.
+
+### Key Metrics in DORA
+
+- **Deployment Frequency**: How often an organization successfully releases to production.
+- **Lead Time for Changes**: The amount of time it takes a commit to get into production.
+- **Change Failure Rate**: The percentage of changes that result in a failure in production.
+- **Time to Restore Service**: How long it takes an organization to recover from a failure in production.
+
+### Key Practices in DORA
+
+- **Version Control**: Using version control systems to manage code changes.
+- **Continuous Integration**: Automatically building and testing code changes.
+- **Automated Testing**: Using automated tests to ensure code quality.
+- **Monitoring and Observability**: Continuously monitoring systems to detect and diagnose issues.

--- a/website/docs/deployment.mdx
+++ b/website/docs/deployment.mdx
@@ -851,3 +851,43 @@ See [docs](https://docs.quantcdn.io/docs/cli/continuous-integration) and [blog](
 [Kinsta Static Site Hosting](https://kinsta.com/static-site-hosting) lets you deploy up to 100 static sites for free, custom domains with SSL, 100 GB monthly bandwidth, and 260+ Cloudflare CDN locations.
 
 Get started in just a few clicks by following our [Docusaurus on Kinsta](https://kinsta.com/docs/docusaurus-example/) article.
+
+## AI Engineering {#ai-engineering}
+
+AI engineering is a discipline that combines principles from software engineering, data science, and machine learning to develop AI systems. It involves the design, development, and deployment of AI models and systems that can perform tasks that typically require human intelligence, such as image recognition, natural language processing, and decision-making.
+
+### Key Concepts in AI Engineering
+
+- **Machine Learning**: A subset of AI that involves training models on data to make predictions or decisions without being explicitly programmed.
+- **Deep Learning**: A subset of machine learning that uses neural networks with many layers to learn from large amounts of data.
+- **Data Engineering**: The process of collecting, storing, and processing data to make it usable for AI models.
+- **Model Deployment**: The process of integrating a trained AI model into a production environment where it can make predictions on new data.
+
+## DevSecOps {#devsecops}
+
+DevSecOps is a practice that integrates security into the DevOps process. It aims to automate and integrate security at every phase of the software development lifecycle, from initial design through integration, testing, deployment, and software delivery.
+
+### Key Concepts in DevSecOps
+
+- **Continuous Integration/Continuous Deployment (CI/CD)**: A practice that involves automatically building, testing, and deploying code changes to production.
+- **Security as Code**: The practice of defining security policies and controls as code, which can be versioned, tested, and deployed just like application code.
+- **Threat Modeling**: The process of identifying and assessing potential security threats to a system.
+- **Vulnerability Management**: The practice of identifying, assessing, and mitigating security vulnerabilities in a system.
+
+## DORA {#dora}
+
+DORA (DevOps Research and Assessment) is a research program that aims to understand the practices and capabilities that drive high performance in software delivery and operations. DORA's research has identified key metrics and practices that are associated with high-performing teams.
+
+### Key Metrics in DORA
+
+- **Deployment Frequency**: How often an organization successfully releases to production.
+- **Lead Time for Changes**: The amount of time it takes a commit to get into production.
+- **Change Failure Rate**: The percentage of changes that result in a failure in production.
+- **Time to Restore Service**: How long it takes an organization to recover from a failure in production.
+
+### Key Practices in DORA
+
+- **Version Control**: Using version control systems to manage code changes.
+- **Continuous Integration**: Automatically building and testing code changes.
+- **Automated Testing**: Using automated tests to ensure code quality.
+- **Monitoring and Observability**: Continuously monitoring systems to detect and diagnose issues.

--- a/website/docs/seo.mdx
+++ b/website/docs/seo.mdx
@@ -218,3 +218,43 @@ Docusaurus uses your file names as links, but you can always change that using s
 Search engines rely on the HTML markup such as `<h2>`, `<table>`, etc., to understand the structure of your webpage. When Docusaurus renders your pages, semantic markup, e.g. `<aside>`, `<nav>`, `<main>`, are used to divide the different sections of the page, helping the search engine to locate parts like sidebar, navbar, and the main page content.
 
 Most [CommonMark](https://spec.commonmark.org/0.30/#atx-headings) syntaxes have their corresponding HTML tags. By using Markdown consistently in your project, you will make it easier for search engines to understand your page content.
+
+## AI Engineering {#ai-engineering}
+
+AI engineering is a discipline that combines principles from software engineering, data science, and machine learning to develop AI systems. It involves the design, development, and deployment of AI models and systems that can perform tasks that typically require human intelligence, such as image recognition, natural language processing, and decision-making.
+
+### Key Concepts in AI Engineering
+
+- **Machine Learning**: A subset of AI that involves training models on data to make predictions or decisions without being explicitly programmed.
+- **Deep Learning**: A subset of machine learning that uses neural networks with many layers to learn from large amounts of data.
+- **Data Engineering**: The process of collecting, storing, and processing data to make it usable for AI models.
+- **Model Deployment**: The process of integrating a trained AI model into a production environment where it can make predictions on new data.
+
+## DevSecOps {#devsecops}
+
+DevSecOps is a practice that integrates security into the DevOps process. It aims to automate and integrate security at every phase of the software development lifecycle, from initial design through integration, testing, deployment, and software delivery.
+
+### Key Concepts in DevSecOps
+
+- **Continuous Integration/Continuous Deployment (CI/CD)**: A practice that involves automatically building, testing, and deploying code changes to production.
+- **Security as Code**: The practice of defining security policies and controls as code, which can be versioned, tested, and deployed just like application code.
+- **Threat Modeling**: The process of identifying and assessing potential security threats to a system.
+- **Vulnerability Management**: The practice of identifying, assessing, and mitigating security vulnerabilities in a system.
+
+## DORA {#dora}
+
+DORA (DevOps Research and Assessment) is a research program that aims to understand the practices and capabilities that drive high performance in software delivery and operations. DORA's research has identified key metrics and practices that are associated with high-performing teams.
+
+### Key Metrics in DORA
+
+- **Deployment Frequency**: How often an organization successfully releases to production.
+- **Lead Time for Changes**: The amount of time it takes a commit to get into production.
+- **Change Failure Rate**: The percentage of changes that result in a failure in production.
+- **Time to Restore Service**: How long it takes an organization to recover from a failure in production.
+
+### Key Practices in DORA
+
+- **Version Control**: Using version control systems to manage code changes.
+- **Continuous Integration**: Automatically building and testing code changes.
+- **Automated Testing**: Using automated tests to ensure code quality.
+- **Monitoring and Observability**: Continuously monitoring systems to detect and diagnose issues.

--- a/website/docs/styling-layout.mdx
+++ b/website/docs/styling-layout.mdx
@@ -311,3 +311,43 @@ To enable TypeScript support for Sass/SCSS modules, the TypeScript configuration
   }
 }
 ```
+
+## AI Engineering {#ai-engineering}
+
+AI engineering is a discipline that combines principles from software engineering, data science, and machine learning to develop AI systems. It involves the design, development, and deployment of AI models and systems that can perform tasks that typically require human intelligence, such as image recognition, natural language processing, and decision-making.
+
+### Key Concepts in AI Engineering
+
+- **Machine Learning**: A subset of AI that involves training models on data to make predictions or decisions without being explicitly programmed.
+- **Deep Learning**: A subset of machine learning that uses neural networks with many layers to learn from large amounts of data.
+- **Data Engineering**: The process of collecting, storing, and processing data to make it usable for AI models.
+- **Model Deployment**: The process of integrating a trained AI model into a production environment where it can make predictions on new data.
+
+## DevSecOps {#devsecops}
+
+DevSecOps is a practice that integrates security into the DevOps process. It aims to automate and integrate security at every phase of the software development lifecycle, from initial design through integration, testing, deployment, and software delivery.
+
+### Key Concepts in DevSecOps
+
+- **Continuous Integration/Continuous Deployment (CI/CD)**: A practice that involves automatically building, testing, and deploying code changes to production.
+- **Security as Code**: The practice of defining security policies and controls as code, which can be versioned, tested, and deployed just like application code.
+- **Threat Modeling**: The process of identifying and assessing potential security threats to a system.
+- **Vulnerability Management**: The practice of identifying, assessing, and mitigating security vulnerabilities in a system.
+
+## DORA {#dora}
+
+DORA (DevOps Research and Assessment) is a research program that aims to understand the practices and capabilities that drive high performance in software delivery and operations. DORA's research has identified key metrics and practices that are associated with high-performing teams.
+
+### Key Metrics in DORA
+
+- **Deployment Frequency**: How often an organization successfully releases to production.
+- **Lead Time for Changes**: The amount of time it takes a commit to get into production.
+- **Change Failure Rate**: The percentage of changes that result in a failure in production.
+- **Time to Restore Service**: How long it takes an organization to recover from a failure in production.
+
+### Key Practices in DORA
+
+- **Version Control**: Using version control systems to manage code changes.
+- **Continuous Integration**: Automatically building and testing code changes.
+- **Automated Testing**: Using automated tests to ensure code quality.
+- **Monitoring and Observability**: Continuously monitoring systems to detect and diagnose issues.

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -156,7 +156,9 @@ function getLocalizedConfigValue(key: keyof typeof ConfigLocalized) {
 export default async function createConfigAsync() {
   return {
     title: 'Docusaurus',
-    tagline: getLocalizedConfigValue('tagline') + ' | AI engineering and DevSecOps',
+    tagline: `${getLocalizedConfigValue(
+      'tagline',
+    )} | AI engineering and DevSecOps`,
     organizationName: 'facebook',
     projectName: 'docusaurus',
     baseUrl,

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -156,7 +156,7 @@ function getLocalizedConfigValue(key: keyof typeof ConfigLocalized) {
 export default async function createConfigAsync() {
   return {
     title: 'Docusaurus',
-    tagline: getLocalizedConfigValue('tagline'),
+    tagline: getLocalizedConfigValue('tagline') + ' | AI engineering and DevSecOps',
     organizationName: 'facebook',
     projectName: 'docusaurus',
     baseUrl,
@@ -251,6 +251,9 @@ export default async function createConfigAsync() {
       description:
         'An optimized site generator in React. Docusaurus helps you to move fast and write content. Build documentation websites, blogs, marketing pages, and more.',
       announcedVersion,
+      aiEngineering: true,
+      devSecOps: true,
+      DORA: true,
     },
     staticDirectories: [
       'static',
@@ -642,6 +645,11 @@ export default async function createConfigAsync() {
             label: 'Community',
             position: 'left',
             activeBaseRegex: `/community/`,
+          },
+          {
+            to: '/dora',
+            label: 'DORA',
+            position: 'left',
           },
           // This item links to a draft doc: only displayed in dev
           {


### PR DESCRIPTION
Update the Docusaurus website to include content for AI engineering, DevSecOps, and DORA.

* **`website/docusaurus.config.ts`**:
  - Update the tagline to include AI engineering and DevSecOps.
  - Add AI engineering, DevSecOps, and DORA to the `customFields`.
  - Add a new navbar item for DORA.

* **`website/docs/advanced/client.mdx`**:
  - Add new sections for AI engineering, DevSecOps, and DORA with key concepts and practices.

* **`website/docs/cli.mdx`**:
  - Add new commands for AI engineering, DevSecOps, and DORA with options.

* **`website/docs/configuration.mdx`**:
  - Add new sections for AI engineering, DevSecOps, and DORA with key concepts and practices.

* **`website/docs/deployment.mdx`**:
  - Add new sections for AI engineering, DevSecOps, and DORA with key concepts and practices.

* **`website/docs/seo.mdx`**:
  - Add new sections for AI engineering, DevSecOps, and DORA with key concepts and practices.

* **`website/docs/styling-layout.mdx`**:
  - Add new sections for AI engineering, DevSecOps, and DORA with key concepts and practices.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dwaynehelena/docusaurus/pull/1?shareId=f3bc2e0f-4d65-485a-a1ed-ec9f5c33c4bf).